### PR TITLE
Fix a style inconsistency between Firefox and Chrome

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -39,6 +39,7 @@ h1 strong {
 hr {
   border: 0;
   margin: 2em 0;
+  color: $text-color;
 
   &:after {
     content: '********************';


### PR DESCRIPTION
Firefox's default CSS stylesheet applies a rule `color: gray` to `<hr>` elements – whereas Chrome doesn't apply a default colour, so `<hr>` elements inherit `color` from the parent.

I've directly applied a colour rule on horizontal rules now to avoid this inconsistency.